### PR TITLE
Fix fullscreen and frameborder

### DIFF
--- a/content/meeting.html
+++ b/content/meeting.html
@@ -35,10 +35,10 @@ All the material related to the PTEROSOR group meeting can be found <a href="htt
             iframe =   document.createElement('iframe');
             iframe.width = 560;
             iframe.height= 315;
-            iframe.frameborder= 0;
+            iframe.setAttribute("frameborder",'0');
             iframe.src = "https://www.youtube.com/embed/"+videoId;
             iframe.allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture";
-            iframe.allowfullscreen=true;
+            iframe.setAttribute("allowfullscreen",'');
             listItem.innerHTML = title +"<br>";
             listItem.appendChild(iframe);
             return listItem;


### PR DESCRIPTION
Fix `fullscreen` and `frameborder` attributes  that require a call to the `setAttribute` function to be set. This bug mainly prevented the activation of full screen for embedded YouTube videos.